### PR TITLE
drivers/sensors/Kconfig: Fix bmi160 help text in Kconfig

### DIFF
--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -146,7 +146,7 @@ config BMI160_I2C_ADDR_68
 	bool "0x68"
 	---help---
 		Default address.
-		If SDO pin is pulled to VDDIO, use 0x69
+		If SDO pin is pulled to GND, use 0x68
 
 config BMI160_I2C_ADDR_69
 	bool "0x69"


### PR DESCRIPTION
## Summary
Fix BMI160_I2C_ADDR_68 help text in Kconfig
## Impact
none
## Testing

